### PR TITLE
Remove rake version restriction

### DIFF
--- a/dartsass-sprockets.gemspec
+++ b/dartsass-sprockets.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency 'mocha'
 
   spec.add_dependency "dartsass-ruby", "~> 3.0"


### PR DESCRIPTION
No need to restrict this to such an old version of rake and safe to run latest like other development dependencies.