### PR TITLE
Remove invalid platform value

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,5 @@
 source 'https://rubygems.org'
 
-platforms :windows do
-  gem 'tzinfo-data'
-end
-
 # for working locally
 # gem "sassc", :path => "../sassc"
 


### PR DESCRIPTION
I'm not sure if you need this but I don't believe it would have worked since builds are failing with a Bundler error that this is an invalid platform value.