### PR TITLE
Alter the config to pass a --quiet-deps flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ After adding this config line, you may need to clear your assets cache
 Note these source maps are *inline* and will be appended to the compiled
 `application.css` file. (They will *not* generate additional files.)
 
+## Silencing Deprecation Warnings That Come From Dependencies
+
+To silence deprecation warnings during compilation that come from dependencies, add the following configuration to your `application.rb` file:
+
+```ruby
+# config/environments/development.rb
+config.sass.quiet_deps = true
+```
+
 ## Alternatives
 
 * [dartsass-rails](https://github.com/rails/dartsass-rails): The Rails organization

--- a/lib/sassc/rails/railtie.rb
+++ b/lib/sassc/rails/railtie.rb
@@ -18,6 +18,9 @@ module SassC
       # Display line comments above each selector as a debugging aid
       config.sass.line_comments = true
 
+      # Silence deprecation warnings during compilation that come from dependencies
+      config.sass.quiet_deps = false
+
       # Set the default stylesheet engine
       # It can be overridden by passing:
       #     --stylesheet_engine=sass

--- a/lib/sassc/rails/template.rb
+++ b/lib/sassc/rails/template.rb
@@ -30,6 +30,7 @@ module SassC
           load_paths: input[:environment].paths,
           functions: @functions,
           importer: @importer_class,
+          quiet_deps: ::Rails.application.config.sass.quiet_deps,
           sprockets: {
             context: context,
             environment: input[:environment],


### PR DESCRIPTION
Adding an option to silence the deprecation warning during compilation.
https://sass-lang.com/documentation/cli/dart-sass/#:~:text=scss%20style.css-,%2D%2Dquiet%2Ddeps,rule%20or%20the%20%40debug%20rule.

This should fix https://github.com/tablecheck/dartsass-sprockets/issues/25 and kind of a workaround for https://github.com/tablecheck/dartsass-sprockets/issues/26