### PR TITLE
Restore import tracking from Sprockets::SassProcessor so that edits to secondary imports are tracked

### DIFF
--- a/lib/sassc/rails/template.rb
+++ b/lib/sassc/rails/template.rb
@@ -3,6 +3,7 @@
 require 'sprockets/version'
 require 'sprockets/sass_processor'
 require 'sprockets/utils'
+require 'sprockets/uri_utils'
 
 module SassC
   module Rails
@@ -42,7 +43,14 @@ module SassC
 
         css = engine.render
 
-        context.metadata.merge(data: css)
+        # Track all imported files
+        sass_dependencies = Set.new([input[:filename]])
+        engine.dependencies.map do |dependency|
+          sass_dependencies << dependency.options[:filename]
+          context.metadata[:dependencies] << Sprockets::URIUtils.build_file_digest_uri(dependency.options[:filename])
+        end
+
+        context.metadata.merge(data: css, sass_dependencies: sass_dependencies)
       end
 
       def config_options

--- a/test/dummy/app/assets/stylesheets/partials/_scss_use.scss
+++ b/test/dummy/app/assets/stylesheets/partials/_scss_use.scss
@@ -1,0 +1,9 @@
+.partial-scss {
+  color: blue; }
+
+@mixin background-from-partial($color) {
+  background-color: $color
+}
+
+@import "subfolder/relative_sass";
+@import "subfolder/relative_not_a_partial";

--- a/test/dummy/app/assets/stylesheets/uses_test.scss
+++ b/test/dummy/app/assets/stylesheets/uses_test.scss
@@ -1,0 +1,7 @@
+@use "partials/scss_use";
+
+.main {
+  color: yellow;
+  @include scss_use.background-from-partial(red);
+}
+


### PR DESCRIPTION
Hi folks! Thanks for dartsass-sprockets!

We ran into the issue of secondary imports not being tracked after converting our stylesheets to `@use`. Restoring the import tracking from the SassProcessor superclass resolved the issue, and perhaps closes #26 too. @nimmolo can you try this branch and verify?